### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "mvn "

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 1、项目初始化
 
 2、加入Mybatis-plus和H2数据库
+
+[![Run on Repl.it](https://repl.it/badge/github/zhonglunsheng/Spring-Boot-Collection)](https://repl.it/github/zhonglunsheng/Spring-Boot-Collection)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@zhonglunsheng/Spring-Boot-Collection).